### PR TITLE
Adds CLI args: `-k/--keypair` and `-u/--url`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,7 +606,12 @@ version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -592,6 +621,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags 1.3.2",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+dependencies = [
+ "atty",
+ "bitflags 1.3.2",
+ "clap_lex 0.2.4",
+ "indexmap 1.9.3",
+ "once_cell",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.16.1",
 ]
 
 [[package]]
@@ -612,8 +672,8 @@ checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex",
- "strsim",
+ "clap_lex 0.7.2",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -626,6 +686,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.77",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -688,6 +757,12 @@ name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -792,7 +867,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.77",
 ]
 
@@ -825,6 +900,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,6 +929,27 @@ dependencies = [
  "block-buffer 0.10.4",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -909,6 +1017,22 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "feature-probe"
@@ -1000,6 +1124,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
@@ -1065,6 +1195,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,6 +1247,16 @@ dependencies = [
  "sized-chunks",
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1203,6 +1366,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+]
+
+[[package]]
 name = "libsecp256k1"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,6 +1460,12 @@ dependencies = [
  "num-bigint",
  "thiserror",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -1453,6 +1632,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "parking_lot"
@@ -1745,6 +1930,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1774,6 +1970,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "rpassword"
+version = "7.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,6 +2009,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+dependencies = [
+ "bitflags 2.6.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1882,6 +2112,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.5.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1928,6 +2171,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1960,6 +2209,57 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "solana-clap-utils"
+version = "1.18.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117bf11e4d15b529dd9dfa2680abaf8bd3c1d8f7cb0586a5accdac5a2ecc7cc5"
+dependencies = [
+ "chrono",
+ "clap 2.34.0",
+ "rpassword",
+ "solana-remote-wallet",
+ "solana-sdk",
+ "thiserror",
+ "tiny-bip39",
+ "uriparse",
+ "url",
+]
+
+[[package]]
+name = "solana-clap-v3-utils"
+version = "1.18.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99f3b4576846b368b1e5eacb26a131b3c4cb7861fb791fcc5ca7013bbd06431e"
+dependencies = [
+ "chrono",
+ "clap 3.2.25",
+ "rpassword",
+ "solana-remote-wallet",
+ "solana-sdk",
+ "solana-zk-token-sdk",
+ "thiserror",
+ "tiny-bip39",
+ "uriparse",
+ "url",
+]
+
+[[package]]
+name = "solana-cli-config"
+version = "1.18.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884f604b0ebb6572103b92b043cfe977ad13137f54c307e9d2c14b8b5079d150"
+dependencies = [
+ "dirs-next",
+ "lazy_static",
+ "serde",
+ "serde_derive",
+ "serde_yaml",
+ "solana-clap-utils",
+ "solana-sdk",
+ "url",
+]
 
 [[package]]
 name = "solana-frozen-abi"
@@ -2062,6 +2362,25 @@ dependencies = [
  "tiny-bip39",
  "wasm-bindgen",
  "zeroize",
+]
+
+[[package]]
+name = "solana-remote-wallet"
+version = "1.18.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9651b3f2c3df39a1a6fc87fe792bdb3ec3d84a8169c0a57c86335b48d6cb1491"
+dependencies = [
+ "console",
+ "dialoguer",
+ "log",
+ "num-derive",
+ "num-traits",
+ "parking_lot",
+ "qstring",
+ "semver",
+ "solana-sdk",
+ "thiserror",
+ "uriparse",
 ]
 
 [[package]]
@@ -2390,15 +2709,32 @@ dependencies = [
 name = "steel-cli"
 version = "1.3.0"
 dependencies = [
- "clap",
+ "anyhow",
+ "clap 3.2.25",
+ "clap 4.5.18",
  "colored",
  "git2",
  "indicatif",
  "prettyplease",
  "quote",
+ "solana-clap-v3-utils",
+ "solana-cli-config",
+ "solana-sdk",
  "syn 2.0.77",
  "tokio",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
@@ -2447,6 +2783,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2454,6 +2803,21 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
@@ -2540,7 +2904,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap",
+ "indexmap 2.5.0",
  "toml_datetime",
  "winnow",
 ]
@@ -2589,6 +2953,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "uriparse"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2620,6 +2990,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -2734,6 +3110,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,19 @@ keywords = ["solana"]
 
 [workspace.dependencies]
 bytemuck = "1.14"
-clap = { features = ["derive"], version = "4.4" }
+clap = { features = ["derive", "env"], version = "4.4" }
+clap_v3 = { version = "3", package = "clap" }
+anyhow = "1"
 colored = "2.0"
 git2 = "0.16"
 indicatif = "0.17"
 num_enum = "0.7"
 prettyplease = "0.2"
 syn = { features = ["full"], version = "2.0" }
+solana-clap-v3-utils = "^1.18"
+solana-cli-config = "^1.18"
 solana-program = "^1.18"
+solana-sdk = "^1.18"
 spl-token = { features = ["no-entrypoint"], version = "^4" }
 spl-associated-token-account = { features = [ "no-entrypoint" ], version = "^2.3" } 
 thiserror = "1.0.57"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,7 +19,9 @@ default = []
 admin = []
 
 [dependencies]
+anyhow.workspace = true
 clap.workspace = true
+clap_v3.workspace = true
 colored.workspace = true
 indicatif.workspace = true 
 git2.workspace = true
@@ -27,3 +29,6 @@ prettyplease.workspace = true
 syn.workspace = true
 tokio.workspace = true
 quote.workspace = true
+solana-sdk.workspace = true
+solana-cli-config.workspace = true
+solana-clap-v3-utils.workspace = true

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,0 +1,85 @@
+use std::str::FromStr;
+
+use anyhow::anyhow;
+use clap::ValueEnum;
+use solana_clap_v3_utils::{
+    input_validators::normalize_to_url_if_moniker, keypair::signer_from_path,
+};
+use solana_cli_config::Config;
+use solana_sdk::{commitment_config::CommitmentConfig, signer::Signer};
+
+/// Load a signer and a client URL from args, sourced in the following order:
+/// 1. Passed in directly to this function.
+/// 2. Values specified in the Solana CLI config YAML file.
+/// 3. Values in `solana_cli_config::Config::default()`.
+pub fn load_client_and_signer(
+    client_url: Option<String>,
+    commitment_arg: Option<CommitmentLevel>,
+    signer_uri: Option<String>,
+) -> anyhow::Result<((String, CommitmentConfig), Box<dyn Signer + 'static>)> {
+    if let (Some(client_url), Some(signer_uri)) = (&client_url, &signer_uri) {
+        let client_url = normalize_to_url_if_moniker(client_url);
+        let commitment = commitment_arg.unwrap_or(CommitmentLevel::Confirmed);
+        let signer = load_signer(&signer_uri)?;
+        Ok(((client_url.clone(), commitment.into()), signer))
+    } else {
+        let Config {
+            keypair_path,
+            json_rpc_url,
+            commitment,
+            ..
+        } = load_config().unwrap_or_default();
+        let url = client_url.unwrap_or(json_rpc_url);
+        let url = normalize_to_url_if_moniker(&url);
+        let commitment = commitment_arg.map(Into::into).unwrap_or(
+            CommitmentConfig::from_str(&commitment).map_err(|_| {
+                anyhow!(
+                    "failed to parse commitment string in config file {:?}",
+                    commitment
+                )
+            })?,
+        );
+        let signer = load_signer(&signer_uri.unwrap_or(keypair_path))?;
+        Ok(((url, commitment), signer))
+    }
+}
+
+/// Load a signer from a URI. This may be a remote wallet, a file, or a seed phrase passed in via command-line.
+/// Some URI schemes allow for specifying a derivation path via a query parameter in the form of: `?path=x/y`.
+pub fn load_signer(signer_uri: &str) -> anyhow::Result<Box<dyn Signer + 'static>> {
+    signer_from_path(
+        &clap_v3::ArgMatches::default(),
+        &signer_uri,
+        "keypair",
+        &mut None,
+    )
+    .map_err(|e| anyhow!("failed to parse signer URI {}", &signer_uri).context(e.to_string()))
+}
+
+/// Load the Solana CLI config from its default location.
+fn load_config() -> anyhow::Result<Config> {
+    let config_file = solana_cli_config::CONFIG_FILE
+        .as_ref()
+        .ok_or_else(|| anyhow!("unable to get config file path"))?;
+    Config::load(&config_file)
+        .map_err(|e| anyhow!("failed to load Solana CLI config file {config_file}: {e}"))
+}
+
+/// Parsed by Clap, supports better help text and error messages.
+#[derive(ValueEnum, Debug, Default, Clone)]
+pub enum CommitmentLevel {
+    Processed,
+    #[default]
+    Confirmed,
+    Finalized,
+}
+
+impl Into<CommitmentConfig> for CommitmentLevel {
+    fn into(self) -> CommitmentConfig {
+        match self {
+            CommitmentLevel::Processed => CommitmentConfig::processed(),
+            CommitmentLevel::Confirmed => CommitmentConfig::confirmed(),
+            CommitmentLevel::Finalized => CommitmentConfig::finalized(),
+        }
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,9 +1,11 @@
 mod args;
+mod config;
 mod new_project;
 mod utils;
 
 use args::*;
 use clap::{command, Parser, Subcommand};
+use config::{load_client_and_signer, CommitmentLevel};
 use new_project::*;
 
 #[derive(Subcommand, Debug)]
@@ -15,13 +17,34 @@ enum Command {
 #[derive(Parser, Debug)]
 #[command(about, version)]
 pub struct Args {
+    /// Sets the primary signer on any subcommands that require a signature.
+    /// Defaults to the signer in Solana CLI's YAML config file which is
+    /// usually located at `~/.config/solana/cli/config.yml`.
+    /// This arg is parsed identically to the vanilla Solana CLI and
+    /// supports `usb://` and `prompt://` URI schemes as well as filepaths to keypair JSON files.
+    #[clap(long, short, env)]
+    keypair: Option<String>,
+    /// Sets the Solana RPC URL.
+    /// Defaults to the `rpc_url` in Solana CLI's YAML config file which is
+    /// usually located at `~/.config/solana/cli/config.yml`.
+    #[clap(long, short, env = "RPC_URL")]
+    url: Option<String>,
+    /// Set the default commitment level of any RPC client requests.
+    #[clap(long, env)]
+    commitment: Option<CommitmentLevel>,
     #[command(subcommand)]
     command: Command,
 }
 
-fn main() {
-    let args = Args::parse();
-    match args.command {
+fn main() -> anyhow::Result<()> {
+    let Args {
+        keypair,
+        url,
+        commitment,
+        command,
+    } = Args::parse();
+    let (_url, _signer) = load_client_and_signer(url, commitment, keypair)?;
+    match command {
         Command::New(args) => new_project(args),
     }
 }

--- a/cli/src/new_project.rs
+++ b/cli/src/new_project.rs
@@ -7,12 +7,13 @@ use crate::{
     NewArgs,
 };
 
-pub fn new_project(args: NewArgs) {
+pub fn new_project(args: NewArgs) -> anyhow::Result<()> {
     let project_name = args.name.to_ascii_lowercase();
     let base_path = Path::new(&project_name);
-    stub_workspace(base_path, &project_name).unwrap();
-    stub_api(base_path, &project_name).unwrap();
-    stub_program(base_path, &project_name).unwrap();
+    stub_workspace(base_path, &project_name)?;
+    stub_api(base_path, &project_name)?;
+    stub_program(base_path, &project_name)?;
+    Ok(())
 }
 
 fn stub_workspace(base_path: &Path, project_name: &String) -> io::Result<()> {


### PR DESCRIPTION
This is not immediately useful to any CLI subcommands in at the moment, but almost certainly will apply to subcommands on the roadmap. It's also useful as something for users of Steel to write CLIs for their own programs. For the latter, it could be dressed up a bit more and turned into a macro wrapping a subcommand enum. 

The goal with this implementation is to adhere to the familiar Solana CLI interface as much as possible, with identical argument parsing as well as responsiveness to values controlled with `solana config set`.

