### PR TITLE
tweak trait impls

### DIFF
--- a/lib/src/macros.rs
+++ b/lib/src/macros.rs
@@ -21,34 +21,6 @@ macro_rules! impl_from_bytes {
 }
 
 #[macro_export]
-macro_rules! impl_account_from_bytes {
-    ($struct_name:ident) => {
-        impl $crate::AccountDeserialize for $struct_name {
-            fn try_from_bytes<'a>(
-                data: &'a [u8],
-            ) -> Result<&'a Self, solana_program::program_error::ProgramError> {
-                if Self::discriminator().ne(&data[0]) {
-                    return Err(solana_program::program_error::ProgramError::InvalidAccountData);
-                }
-                bytemuck::try_from_bytes::<Self>(&data[8..]).or(Err(
-                    solana_program::program_error::ProgramError::InvalidAccountData,
-                ))
-            }
-            fn try_from_bytes_mut<'a>(
-                data: &'a mut [u8],
-            ) -> Result<&'a mut Self, solana_program::program_error::ProgramError> {
-                if Self::discriminator().ne(&data[0]) {
-                    return Err(solana_program::program_error::ProgramError::InvalidAccountData);
-                }
-                bytemuck::try_from_bytes_mut::<Self>(&mut data[8..]).or(Err(
-                    solana_program::program_error::ProgramError::InvalidAccountData,
-                ))
-            }
-        }
-    };
-}
-
-#[macro_export]
 macro_rules! impl_instruction_from_bytes {
     ($struct_name:ident) => {
         impl $struct_name {
@@ -67,7 +39,6 @@ macro_rules! impl_instruction_from_bytes {
 macro_rules! account {
     ($discriminator_name:ident, $struct_name:ident) => {
         $crate::impl_to_bytes!($struct_name);
-        $crate::impl_account_from_bytes!($struct_name);
 
         impl $crate::Discriminator for $struct_name {
             fn discriminator() -> u8 {

--- a/lib/src/traits.rs
+++ b/lib/src/traits.rs
@@ -6,6 +6,68 @@ pub trait AccountDeserialize {
     fn try_from_bytes_mut(data: &mut [u8]) -> Result<&mut Self, ProgramError>;
 }
 
+impl<T> AccountDeserialize for T
+where
+    T: Discriminator + Pod,
+{
+    fn try_from_bytes(data: &[u8]) -> Result<&Self, ProgramError> {
+        if Self::discriminator().ne(&data[0]) {
+            return Err(solana_program::program_error::ProgramError::InvalidAccountData);
+        }
+        bytemuck::try_from_bytes::<Self>(&data[8..]).or(Err(
+            solana_program::program_error::ProgramError::InvalidAccountData,
+        ))
+    }
+
+    fn try_from_bytes_mut(data: &mut [u8]) -> Result<&mut Self, ProgramError> {
+        if Self::discriminator().ne(&data[0]) {
+            return Err(solana_program::program_error::ProgramError::InvalidAccountData);
+        }
+        bytemuck::try_from_bytes_mut::<Self>(&mut data[8..]).or(Err(
+            solana_program::program_error::ProgramError::InvalidAccountData,
+        ))
+    }
+}
+
+/// Account data is sometimes stored via a header and body type,
+/// where the former resolves the type of the latter (e.g. merkle trees with a generic size const).
+/// This trait parses a header type from the first N bytes of some data, and returns the remaining
+/// bytes, which are then available for further processing.
+///
+/// See module-level tests for example usage.
+pub trait AccountHeaderDeserialize {
+    fn try_header_from_bytes(data: &[u8]) -> Result<(&Self, &[u8]), ProgramError>;
+    fn try_header_from_bytes_mut(data: &mut [u8]) -> Result<(&mut Self, &mut [u8]), ProgramError>;
+}
+
+impl<T> AccountHeaderDeserialize for T
+where
+    T: Discriminator + Pod,
+{
+    fn try_header_from_bytes(data: &[u8]) -> Result<(&Self, &[u8]), ProgramError> {
+        if Self::discriminator().ne(&data[0]) {
+            return Err(solana_program::program_error::ProgramError::InvalidAccountData);
+        }
+        let (prefix, remainder) = data[8..].split_at(std::mem::size_of::<T>());
+        Ok((
+            bytemuck::try_from_bytes::<Self>(prefix).or(Err(
+                solana_program::program_error::ProgramError::InvalidAccountData,
+            ))?,
+            remainder,
+        ))
+    }
+
+    fn try_header_from_bytes_mut(data: &mut [u8]) -> Result<(&mut Self, &mut [u8]), ProgramError> {
+        let (prefix, remainder) = data[8..].split_at_mut(std::mem::size_of::<T>());
+        Ok((
+            bytemuck::try_from_bytes_mut::<Self>(prefix).or(Err(
+                solana_program::program_error::ProgramError::InvalidAccountData,
+            ))?,
+            remainder,
+        ))
+    }
+}
+
 pub trait AccountValidation {
     fn check<F>(&self, condition: F) -> Result<&Self, ProgramError>
     where
@@ -38,14 +100,14 @@ pub trait Discriminator {
     fn discriminator() -> u8;
 }
 
-pub trait ToAccount {
-    fn to_account<T>(&self, program_id: &Pubkey) -> Result<&T, ProgramError>
-    where
-        T: AccountDeserialize + Discriminator + Pod;
+/// Performs:
+/// 1. Program owner check
+/// 2. Discriminator byte check
+/// 3. Checked bytemuck conversion of account data to &T or &mut T.
+pub trait AsProgramAccount<T> {
+    fn as_program_account(&self, program_id: &Pubkey) -> Result<&T, ProgramError>;
 
-    fn to_account_mut<T>(&self, program_id: &Pubkey) -> Result<&mut T, ProgramError>
-    where
-        T: AccountDeserialize + Discriminator + Pod;
+    fn as_program_account_mut(&mut self, program_id: &Pubkey) -> Result<&mut T, ProgramError>;
 }
 
 #[cfg(feature = "spl")]
@@ -57,4 +119,76 @@ pub trait ToSplToken {
         owner: &Pubkey,
         mint: &Pubkey,
     ) -> Result<spl_token::state::Account, ProgramError>;
+}
+
+pub trait ProgramOwner {
+    fn owner() -> Pubkey;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytemuck::{Pod, Zeroable};
+
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    struct GenericallySizedType<const N: usize> {
+        field: [u32; N],
+    }
+
+    unsafe impl<const N: usize> Zeroable for GenericallySizedType<N> {}
+    unsafe impl<const N: usize> Pod for GenericallySizedType<N> {}
+
+    #[repr(C)]
+    #[derive(Copy, Clone, Zeroable, Pod)]
+    struct GenericallySizedTypeHeader {
+        field_len: u64,
+    }
+
+    impl Discriminator for GenericallySizedTypeHeader {
+        fn discriminator() -> u8 {
+            0
+        }
+    }
+
+    #[test]
+    fn account_headers() {
+        let mut data = [0u8; 32];
+        data[8] = 4;
+        data[16] = 5;
+        let (_foo_header, foo) = GenericallySizedTypeHeader::try_header_from_bytes(&data)
+            .map(|(header, remainder)| {
+                let foo = match header.field_len {
+                    4 => bytemuck::try_from_bytes::<GenericallySizedType<4>>(remainder).unwrap(),
+                    x => panic!("{}", format!("unknown field len, {x}")),
+                };
+                (header, foo)
+            })
+            .unwrap();
+        assert_eq!(5, foo.field[0]);
+    }
+
+    #[repr(C)]
+    #[derive(Copy, Clone, Zeroable, Pod)]
+    struct TestType {
+        field0: u64,
+        field1: u64,
+    }
+
+    impl Discriminator for TestType {
+        fn discriminator() -> u8 {
+            7
+        }
+    }
+
+    #[test]
+    fn account_deserialize() {
+        let mut data = [0u8; 24];
+        data[0] = 7;
+        data[8] = 42;
+        data[16] = 43;
+        let foo = TestType::try_from_bytes(&data).unwrap();
+        assert_eq!(42, foo.field0);
+        assert_eq!(43, foo.field1);
+    }
 }


### PR DESCRIPTION
Not sure how you feel about blanket trait implementations because I do see the macros that are code-generating impls for things like `AccountDeserialize`. This draft has a blanket implementation for some of the traits. 

It also adds a trait for deserializing headers, returning the remaining account data bytes raw, available for further processing. This is necessary for things like merkle tree accounts in the SPL account compression program, and other similar account types whose "body" type is resolved at runtime with the help of metadata in a header type.

It also renames `ToAccount` to `AsProgramAccount`, in anticipation of some test-related traits for converting some `T: ProgramOwner + Discriminator + Pod` into a full Solana account (with owner, lamports defaulting to rent except balance, etc), which is something I've found _incredibly_ useful when I've written e2e tests and need to load a bunch of pre-generated accounts into SVM. 