### PR TITLE
fix(template): fixed typo in Cargo.toml

### DIFF
--- a/cli/src/template/cargo_toml
+++ b/cli/src/template/cargo_toml
@@ -8,7 +8,7 @@ edition = "2021"
 license = "Apache-2.0"
 homepage = ""
 documentation = ""
-respository = ""
+repository = ""
 readme = "./README.md"
 keywords = ["solana"]
 


### PR DESCRIPTION
There was a typo in the Cargo.toml file that would create a completely broken project. First things users would notice when doing `steel new` is that the rust analyzer will complain, and the compilation will fail.

This PR fixes that.

I guess a new version of the CLI would be required.

![image](https://github.com/user-attachments/assets/6fea51e8-fce9-496e-8f5c-60babf3c37f3)
