### PR TITLE
Add Support for --nocapture Flag in steel test

### DIFF
--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -13,7 +13,11 @@ pub struct NewArgs {
 pub struct BuildArgs {}
 
 #[derive(Parser, Debug)]
-pub struct TestArgs {}
+pub struct TestArgs {
+    /// Run tests without capturing output
+    #[arg(long)]
+    pub nocapture: bool
+}
 
 #[derive(Parser, Debug)]
 pub struct CleanArgs {}

--- a/cli/src/test_project.rs
+++ b/cli/src/test_project.rs
@@ -2,9 +2,15 @@ use std::process::{Command, Stdio};
 
 use crate::TestArgs;
 
-pub fn test_project(_args: TestArgs) -> anyhow::Result<()> {
-    Command::new("cargo")
-        .arg("test-sbf")
+pub fn test_project(args: TestArgs) -> anyhow::Result<()> {
+    let mut command = Command::new("cargo");
+        command.arg("test-sbf");
+
+        if args.nocapture {
+            command.arg("--").arg("--nocapture");
+        }
+
+        command
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .status()


### PR DESCRIPTION
This PR adds support for the --nocapture flag in the steel test command. 

Closes #61


